### PR TITLE
MSVC compilers does not take the GCC/Clang standard and optimization flags

### DIFF
--- a/CGL/CMakeLists.txt
+++ b/CGL/CMakeLists.txt
@@ -130,7 +130,7 @@ if(WIN32)
 
   if(MSVC)
 
-    set(MSVC_CXX_FLAGS "-std=c++11")
+    set(MSVC_CXX_FLAGS "/std:c++11 /Oi /O2")
 
     if(CGL_BUILD_DEBUG)
         set(CMAKE_BUILD_TYPE Debug)
@@ -145,7 +145,7 @@ if(WIN32)
 
   if(MINGW)
 
-    set(MSVC_CXX_FLAGS "-std=c++11")
+    set(MSVC_CXX_FLAGS "/std:c++11 /Oi /O2")
 
     if(CGL_BUILD_DEBUG)
         set(CMAKE_BUILD_TYPE Debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if(WIN32)
 
   if(MSVC)
 
-    set(MSVC_CXX_FLAGS "-std=gnu++11")
+    set(MSVC_CXX_FLAGS "/std:c++11 /Oi /O2")
 
     if(BUILD_DEBUG)
         set(CMAKE_BUILD_TYPE Debug)
@@ -101,7 +101,7 @@ if(WIN32)
 
   if(MINGW)
 
-    set(MSVC_CXX_FLAGS "-std=gnu++11")
+    set(MSVC_CXX_FLAGS "/std:c++11 /Oi /O2")
 
     if(BUILD_DEBUG)
         set(CMAKE_BUILD_TYPE Debug)


### PR DESCRIPTION
As mentioned in the title, MSVC doesn't support `-std=gnu++11` and `-O2`, but the corresponding M$ version is `\std:c++11` and `\O2`. This change provides the same level of optimization and feature sets to windows build as unix builds